### PR TITLE
Set markdown-link-checker job runner to ubuntu-22.04

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -42,7 +42,7 @@ jobs:
 
   check-markdown-links:
     name: Check Markdown links
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4.2.2


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small change to the `.github/workflows/code-checks.yml` file. The change updates the `runs-on` parameter for the `check-markdown-links` job to use `ubuntu-22.04` instead of `ubuntu-latest`.