### PR TITLE
Fix Security Policy Links

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -6,7 +6,7 @@ If you discover a security vulnerability within this project, please report it t
 
 To report a vulnerability:
 
-1. Go to the [Security tab](https://github.com/JackPlowman/status-sentinel/security) of the repository.
+1. Go to the [Security tab](https://github.com/JackPlowman/aws-timing-scripts/security) of the repository.
 2. Click on "Report a vulnerability".
 3. Follow the instructions to provide details about the vulnerability.
 
@@ -20,6 +20,6 @@ We release patches for security vulnerabilities in the following versions:
 
 ## Security Updates
 
-We will notify users about security updates through the repository's release notes and the [Security Advisories](https://github.com/JackPlowman/status-sentinel/security/advisories) section.
+We will notify users about security updates through the repository's release notes and the [Security Advisories](https://github.com/JackPlowman/aws-timing-scripts/security/advisories) section.
 
 Thank you for helping to keep this project secure.


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes updates to the `docs/SECURITY.md` file to correct the repository links for reporting vulnerabilities and viewing security advisories.

Changes to security documentation:

* [`docs/SECURITY.md`](diffhunk://#diff-2605206b7e64be69186fabc8e8fed35676e0015832ff630141aa4aecd73354e0L9-R9): Updated the link for reporting vulnerabilities to point to the correct repository.
* [`docs/SECURITY.md`](diffhunk://#diff-2605206b7e64be69186fabc8e8fed35676e0015832ff630141aa4aecd73354e0L23-R23): Updated the link for viewing security advisories to point to the correct repository.