### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -53,7 +53,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Check Markdown links
-        uses: UmbrellaDocs/action-linkspector@v1.3.1
+        uses: UmbrellaDocs/action-linkspector@v1.3.2
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           config_file: .github/other-configurations/.linkspector.yml
@@ -72,7 +72,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Set up Just
-        uses: extractions/setup-just@v2
+        uses: extractions/setup-just@v3
       - name: Check Justfile Format
         run: just format-check
 
@@ -92,13 +92,13 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3.28.1
+        uses: github/codeql-action/init@v3.28.13
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality
           config-file: .github/other-configurations/codeql-config.yml
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3.28.1
+        uses: github/codeql-action/analyze@v3.28.13
 
   run-code-limit:
     name: Run CodeLimit
@@ -127,7 +127,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v5.1.0
+        uses: astral-sh/setup-uv@v5.4.0
         with:
           version: "latest"
       - name: Run zizmor 🌈
@@ -135,7 +135,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3.28.1
+        uses: github/codeql-action/upload-sarif@v3.28.13
         with:
           sarif_file: results.sarif
           category: zizmor
@@ -153,7 +153,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Pinning a minor version of uv
-        uses: astral-sh/setup-uv@v5.1.0
+        uses: astral-sh/setup-uv@v5.4.0
         with:
           version: "0.5.13"
       - name: Install Ruff
@@ -167,7 +167,7 @@ jobs:
           RUFF_OUTPUT_FILE: "ruff-results.sarif"
         continue-on-error: true
       - name: Upload Ruff analysis results to GitHub
-        uses: github/codeql-action/upload-sarif@v3.28.1
+        uses: github/codeql-action/upload-sarif@v3.28.13
         with:
           sarif_file: ruff-results.sarif
           wait-for-processing: true


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates several dependencies in the `.github/workflows/code-checks.yml` file to ensure the latest versions are used for various actions. The most important changes include updating the versions of `action-linkspector`, `setup-just`, `codeql-action`, and `setup-uv`.

Dependency updates:

* Updated `UmbrellaDocs/action-linkspector` from `v1.3.1` to `v1.3.2` for checking Markdown links.
* Updated `extractions/setup-just` from `v2` to `v3` for setting up Just.
* Updated `github/codeql-action` for both `init` and `analyze` from `v3.28.1` to `v3.28.13` for CodeQL analysis. [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L95-R101) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L130-R138) [[3]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L170-R170)
* Updated `astral-sh/setup-uv` from `v5.1.0` to `v5.4.0` for installing the latest version of uv. [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L130-R138) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L156-R156)