### PR TITLE
Remove CodeQL Configuration

### DIFF
--- a/.github/other-configurations/codeql-config.yml
+++ b/.github/other-configurations/codeql-config.yml
@@ -1,3 +1,0 @@
-query-filters:
-  - exclude:
-      id: actions/unpinned-tag

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -96,7 +96,6 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality
-          config-file: .github/other-configurations/codeql-config.yml
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3.28.13
 


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the CodeQL configuration by removing a custom query filter and simplifying the workflow configuration. The most important changes include the removal of an exclusion filter for unpinned tags and the elimination of a reference to a custom CodeQL configuration file.

### CodeQL Configuration Updates:

* [`.github/other-configurations/codeql-config.yml`](diffhunk://#diff-687a0af9316072cbdab79cdb046aac181231f8b5f3b5502bc796a9d949ce65beL1-L3): Removed the exclusion filter for the `actions/unpinned-tag` query, which was previously used to suppress warnings about unpinned tags in GitHub Actions.

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L99): Removed the `config-file` parameter referencing the custom CodeQL configuration file, simplifying the workflow to use the default CodeQL settings.