### PR TITLE
Pin GitHub Actions

### DIFF
--- a/.github/other-configurations/pinact.yml
+++ b/.github/other-configurations/pinact.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/suzuki-shunsuke/pinact/refs/heads/main/json-schema/pinact.json
+# pinact - https://github.com/suzuki-shunsuke/pinact
+version: 3
+
+ignore_actions:
+  - name: actions/.*
+    ref: .*
+  - name: github/codeql-action/.*
+    ref: .*

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -26,7 +26,7 @@ jobs:
           persist-credentials: false
       # Lint and Format everything but Python
       - name: Lint Code Base
-        uses: super-linter/super-linter/slim@v7.3.0
+        uses: super-linter/super-linter/slim@4e8a7c2bf106c4c766c816b35ec612638dc9b6b2 # v7.3.0
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: main
@@ -53,7 +53,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Check Markdown links
-        uses: UmbrellaDocs/action-linkspector@v1.3.2
+        uses: UmbrellaDocs/action-linkspector@49cf4f8da82db70e691bb8284053add5028fa244 # v1.3.2
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           config_file: .github/other-configurations/.linkspector.yml
@@ -72,7 +72,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Set up Just
-        uses: extractions/setup-just@v3
+        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
       - name: Check Justfile Format
         run: just format-check
 
@@ -112,7 +112,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: "Run CodeLimit"
-        uses: getcodelimit/codelimit-action@v1
+        uses: getcodelimit/codelimit-action@a036c6897be9ccf69cde9dfe50eafa8cd79c98f8 # v1
 
   run-zizmor:
     name: Check GitHub Actions with zizmor
@@ -126,7 +126,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v5.4.0
+        uses: astral-sh/setup-uv@22695119d769bdb6f7032ad67b9bca0ef8c4a174 # v5.4.0
         with:
           version: "latest"
       - name: Run zizmor 🌈
@@ -152,7 +152,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Pinning a minor version of uv
-        uses: astral-sh/setup-uv@v5.4.0
+        uses: astral-sh/setup-uv@22695119d769bdb6f7032ad67b9bca0ef8c4a174 # v5.4.0
       - name: Install Ruff
         run: uv tool install ruff
       - name: Install Vulture
@@ -189,7 +189,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v5.4.0
+        uses: astral-sh/setup-uv@22695119d769bdb6f7032ad67b9bca0ef8c4a174 # v5.4.0
         with:
           version: "latest"
       - name: Run Lefthook Validate

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -21,7 +21,7 @@ jobs:
           configuration-path: .github/other-configurations/labeller.yml
           sync-labels: true
       - name: Add Size Labels
-        uses: pascalgn/size-label-action@v0.5.5
+        uses: pascalgn/size-label-action@f8edde36b3be04b4f65dcfead05dc8691b374348 # v0.5.5
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Sync labels
-        uses: micnncim/action-label-syncer@v1.3.0
+        uses: micnncim/action-label-syncer@3abd5ab72fda571e69fffd97bd4e0033dd5f495c # v1.3.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.repository }}

--- a/Justfile
+++ b/Justfile
@@ -47,6 +47,22 @@ zizmor-check:
     zizmor .
 
 # ------------------------------------------------------------------------------
+# Pinact
+# ------------------------------------------------------------------------------
+
+# Run pinact
+pinact-run:
+    pinact run -c .github/other-configurations/pinact.yml
+
+# Run pinact checking
+pinact-check:
+    pinact run -c .github/other-configurations/pinact.yml --verify --check
+
+# Run pinact update
+pinact-update:
+    pinact run -c .github/other-configurations/pinact.yml --update
+
+# ------------------------------------------------------------------------------
 # Git Hooks
 # ------------------------------------------------------------------------------
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -18,3 +18,5 @@ pre-commit:
       run: just lefthook-validate
     Zizmor Checks:
       run: just zizmor-check
+    Pinact Checks:
+      run: just pinact-check


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces the integration of Pinact for action pinning and updates several GitHub Actions to use commit SHAs instead of version tags for improved security and reproducibility. Additionally, it includes updates to workflows and configuration files to support these changes.

### Pinact Integration:
* Added a new `pinact.yml` configuration file to define ignored actions and their refs, enabling the use of Pinact for managing pinned actions. (`.github/other-configurations/pinact.yml`)
* Added new `Justfile` tasks (`pinact-run`, `pinact-check`, and `pinact-update`) to facilitate running and verifying Pinact configurations. (`Justfile`)
* Updated `lefthook.yml` to include a new pre-commit hook for Pinact checks. (`lefthook.yml`)

### GitHub Actions Pinning:
* Replaced version tags with commit SHAs for all GitHub Actions in `.github/workflows` to ensure reproducibility and prevent unexpected changes:
  - Updated `super-linter`, `action-linkspector`, `setup-just`, `codelimit-action`, and `setup-uv` in `code-checks.yml`. (`.github/workflows/code-checks.yml`) [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L29-R29) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L56-R56) [[3]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L75-R75) [[4]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L115-R115) [[5]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L129-R129) [[6]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L155-R155) [[7]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L192-R192)
  - Updated `size-label-action` in `pull-request-tasks.yml`. (`.github/workflows/pull-request-tasks.yml`)
  - Updated `action-label-syncer` in `sync-labels.yml`. (`.github/workflows/sync-labels.yml`)
