### PR TITLE
Update Dependabot Groups and Configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,11 +6,15 @@ updates:
     schedule:
       interval: "cron"
       cronjob: "30 7 * * *"
+      timezone: "Europe/London"
     target-branch: "main"
     groups:
       github-actions:
+        applies-to: "version-updates"
         patterns:
           - "*"
+        exclude-patterns:
+          - "super-linter/*"
         update-types:
           - "patch"
           - "minor"


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the Dependabot configuration to refine scheduling, specify a timezone, and improve grouping rules for dependency updates.

### Dependabot configuration updates:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R9-R17): Added the `timezone` field to the schedule, setting it to `"Europe/London"`.
* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R9-R17): Enhanced the `github-actions` group by adding `applies-to: "version-updates"`, introducing `exclude-patterns` to exclude updates matching `"super-linter/*"`, and refining patterns for dependency updates.