### PR TITLE
Bump GitHub Actions

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -53,7 +53,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Check Markdown links
-        uses: UmbrellaDocs/action-linkspector@49cf4f8da82db70e691bb8284053add5028fa244 # v1.3.2
+        uses: UmbrellaDocs/action-linkspector@a0567ce1c7c13de4a2358587492ed43cab5d0102 # v1.3.4
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           config_file: .github/other-configurations/.linkspector.yml
@@ -112,7 +112,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: "Run CodeLimit"
-        uses: getcodelimit/codelimit-action@a036c6897be9ccf69cde9dfe50eafa8cd79c98f8 # v1
+        uses: getcodelimit/codelimit-action@a036c6897be9ccf69cde9dfe50eafa8cd79c98f8 # v1.0.0
 
   run-zizmor:
     name: Check GitHub Actions with zizmor
@@ -126,7 +126,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@22695119d769bdb6f7032ad67b9bca0ef8c4a174 # v5.4.0
+        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
         with:
           version: "latest"
       - name: Run zizmor 🌈
@@ -152,7 +152,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Pinning a minor version of uv
-        uses: astral-sh/setup-uv@22695119d769bdb6f7032ad67b9bca0ef8c4a174 # v5.4.0
+        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
       - name: Install Ruff
         run: uv tool install ruff
       - name: Install Vulture
@@ -189,7 +189,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@22695119d769bdb6f7032ad67b9bca0ef8c4a174 # v5.4.0
+        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
         with:
           version: "latest"
       - name: Run Lefthook Validate


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates several GitHub Actions in the `.github/workflows/code-checks.yml` file to use newer versions of their respective actions. These updates ensure the workflows are using the latest features and fixes provided by the action maintainers.

### Updates to GitHub Actions:

* **Markdown Link Checker**: Updated the `UmbrellaDocs/action-linkspector` action from version `v1.3.2` to `v1.3.4` for checking Markdown links.

* **CodeLimit**: Updated the `getcodelimit/codelimit-action` action to explicitly specify version `v1.0.0` instead of the previous shorthand `v1`.

* **UV Tool**:
  * Updated the `astral-sh/setup-uv` action from version `v5.4.0` to `v6.0.1` in multiple steps where it is used to install or pin the UV tool. [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L129-R129) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L155-R155) [[3]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L192-R192)
