### PR TITLE
Change Jobs to Common Code Checks

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -42,38 +42,15 @@ jobs:
           VALIDATE_PYTHON_PYINK: false
           VALIDATE_NATURAL_LANGUAGE: false
 
-  check-markdown-links:
-    name: Check Markdown links
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Check Markdown links
-        uses: UmbrellaDocs/action-linkspector@a0567ce1c7c13de4a2358587492ed43cab5d0102 # v1.3.4
-        with:
-          github_token: ${{ secrets.GH_TOKEN }}
-          config_file: .github/other-configurations/.linkspector.yml
-          reporter: github-pr-review
-          fail_on_error: true
-          filter_mode: nofilter
-          show_stats: true
-
-  check-justfile-format:
-    name: Check Justfile Format
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Set up Just
-        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
-      - name: Check Justfile Format
-        run: just format-check
+  common-code-checks:
+    name: Common Code Checks
+    permissions:
+      contents: read
+      pull-requests: read
+      security-events: write
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@14445779094fde883fdb9f65946fcae6c25f46c0 # v2025.05.14.01
+    secrets:
+      workflow_github_token: ${{ secrets.GITHUB_TOKEN }}
 
   run-codeql-analysis:
     name: CodeQL Analysis
@@ -112,31 +89,6 @@ jobs:
           persist-credentials: false
       - name: "Run CodeLimit"
         uses: getcodelimit/codelimit-action@a036c6897be9ccf69cde9dfe50eafa8cd79c98f8 # v1.0.0
-
-  run-zizmor:
-    name: Check GitHub Actions with zizmor
-    runs-on: ubuntu-latest
-    permissions:
-      security-events: write
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
-      - name: Set up Just
-        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
-      - name: Run zizmor 🌈
-        run: just zizmor-check-sarif
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@ff0a06e83cb2de871e5a09832bc6a81e7276941f # v3.28.18
-        with:
-          sarif_file: results.sarif
-          category: zizmor
 
   run-python-code-checks:
     name: Run Python Code Checks
@@ -177,19 +129,3 @@ jobs:
           RUFF_OUTPUT_FORMAT: "github"
       - name: Check Python Code for Dead Code (Vulture)
         run: uv run vulture .
-
-  lefthook-validate:
-    name: Lefthook Validate
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
-        with:
-          version: "latest"
-      - name: Run Lefthook Validate
-        run: uvx lefthook validate


### PR DESCRIPTION
# Pull Request

## Description

This pull request consolidates multiple individual code-checking workflows into a single reusable workflow to simplify and streamline the GitHub Actions configuration. The changes remove several specific jobs and replace them with a unified `common-code-checks` workflow.

### Consolidation of Code-Checking Workflows:
* Removed the `check-markdown-links` job and replaced it with the `common-code-checks` reusable workflow. The new workflow handles markdown link checks and other validations. (`.github/workflows/code-checks.yml`, [.github/workflows/code-checks.ymlL45-R53](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L45-R53))
* Removed the `check-justfile-format` job in favor of the `common-code-checks` reusable workflow. (`.github/workflows/code-checks.yml`, [.github/workflows/code-checks.ymlL45-R53](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L45-R53))
* Removed the `run-zizmor` job, which checked GitHub Actions configurations, as its functionality is now covered by the `common-code-checks` workflow. (`.github/workflows/code-checks.yml`, [.github/workflows/code-checks.ymlL116-L140](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L116-L140))
* Removed the `lefthook-validate` job, which validated Lefthook configurations, consolidating it into the `common-code-checks` workflow. (`.github/workflows/code-checks.yml`, [.github/workflows/code-checks.ymlL180-L195](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L180-L195))