### PR TITLE
Set Python Version

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,5 +1,5 @@
 # https://github.com/evilmartians/lefthook
-min_version: 1.11.11
+min_version: 1.11.13
 colors: true
 
 output:

--- a/time_lambda_durations.py
+++ b/time_lambda_durations.py
@@ -1,5 +1,5 @@
 # /// script
-# requires-python = ">=3.13"
+# requires-python = "~=3.13"
 # dependencies = [
 #     "boto3",
 #     "pandas",

--- a/time_sfn_durations.py
+++ b/time_sfn_durations.py
@@ -1,5 +1,5 @@
 # /// script
-# requires-python = ">=3.13"
+# requires-python = "~=3.13"
 # dependencies = [
 #     "boto3",
 #     "pandas",


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes minor updates to configuration files and Python script metadata to ensure compatibility and maintain consistency.

Version updates:

* [`lefthook.yml`](diffhunk://#diff-ad6a01e589b8b1b214ca310dbb8d2e4314f6c612b921050c73c97455de43884dL2-R2): Updated the `min_version` of Lefthook from `1.11.11` to `1.11.13` to reflect the latest required version.

Python script metadata adjustments:

* `time_lambda_durations.py` and `time_sfn_durations.py`: Changed the `requires-python` specifier from `">=3.13"` to `"~=3.13"` to enforce compatibility with Python 3.13.x versions only. [[1]](diffhunk://#diff-55d55dd3c8b141a2c16f50916496ac923eaad796523df5bf86ca0b4b632b2271L2-R2) [[2]](diffhunk://#diff-71d3f9b879274a1a51fdfb784a2046ad98121c9a1e12f2205e54d1d649fea422L2-R2)