### PR TITLE
Migrate to Reusable CodeQL Workflow

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -51,28 +51,17 @@ jobs:
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}
 
-  run-codeql-analysis:
+  codeql-checks:
     name: CodeQL Analysis
-    runs-on: ubuntu-latest
     permissions:
-      statuses: write
+      contents: read
       security-events: write
     strategy:
       matrix:
-        language: [python, actions]
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@ff0a06e83cb2de871e5a09832bc6a81e7276941f # v3.28.18
-        with:
-          languages: ${{ matrix.language }}
-          queries: security-and-quality
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@ff0a06e83cb2de871e5a09832bc6a81e7276941f # v3.28.18
+        language: [actions, python]
+    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@75ceb782a5815a98162de1321c852df74830a493 # v2025.05.24.01
+    with:
+      language: ${{ matrix.language }}
 
   run-code-limit:
     name: Run CodeLimit


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the CodeQL workflow configuration in `.github/workflows/code-checks.yml` to use a reusable workflow, simplifying the setup and improving maintainability.

### Workflow configuration updates:

* Renamed the `run-codeql-analysis` job to `codeql-checks` for consistency and clarity.
* Replaced the inline job definition with a reusable workflow from `JackPlowman/reusable-workflows` to streamline the CodeQL analysis process.
* Adjusted permissions for the `codeql-checks` job, changing `statuses: write` to `contents: read` for better security practices.
* Updated the matrix configuration for the `codeql-checks` job to use `[actions, python]` as the languages.