### PR TITLE
Update SuperLinter to v8.0.0

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -28,7 +28,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Lint Code Base
-        uses: super-linter/super-linter@12150456a73e248bdc94d0794898f94e23127c88 # v7.4.0
+        uses: super-linter/super-linter@5119dcd8011e92182ce8219d9e9efc82f16fddb6 # v8.0.0
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: main


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the version of the `super-linter` GitHub Action used in the `code-checks` workflow to ensure the latest linting rules and features are applied.

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L31-R31): Updated `super-linter` from version `v7.4.0` to `v8.0.0` by changing the commit hash in the `uses` field.