### PR TITLE
Update Ruff Configuration

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -1,32 +1,3 @@
-exclude = [
-    ".bzr",
-    ".direnv",
-    ".eggs",
-    ".git",
-    ".git-rewrite",
-    ".hg",
-    ".ipynb_checkpoints",
-    ".mypy_cache",
-    ".nox",
-    ".pants.d",
-    ".pyenv",
-    ".pytest_cache",
-    ".pytype",
-    ".ruff_cache",
-    ".svn",
-    ".tox",
-    ".venv",
-    ".vscode",
-    "__pypackages__",
-    "_build",
-    "buck-out",
-    "build",
-    "dist",
-    "node_modules",
-    "site-packages",
-    "venv",
-]
-
 target-version = "py313"
 
 [lint]
@@ -42,8 +13,6 @@ ignore = [
 ]
 
 fixable = ["ALL"]
-unfixable = []
-dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
 [format]
 quote-style = "double"


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `ruff.toml` configuration file, primarily simplifying the configuration by removing unused or redundant settings. The most notable changes are the removal of the `exclude` list and cleanup of linting options.

Configuration simplification:

* Removed the entire `exclude` list, which previously specified directories and files to be ignored by Ruff. This will cause Ruff to use its default exclusion behavior.
* Removed the `unfixable` and `dummy-variable-rgx` linting options, streamlining the linting configuration.