### PR TITLE
Update License to Licence

### DIFF
--- a/.github/other-configurations/labeller.yml
+++ b/.github/other-configurations/labeller.yml
@@ -25,7 +25,7 @@ markdown:
               [
                 "docs/*.md",
                 "*.md",
-                "LICENSE",
+                "LICENCE",
                 ".github/pull_request_template.md",
               ]
 python:


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes a minor correction to the documentation labeling configuration. The change updates the spelling of the license file in the `markdown:` section of `.github/other-configurations/labeller.yml` to match the actual file name.

* Changed the file name from `LICENSE` to `LICENCE` in the markdown label configuration.